### PR TITLE
Broaden Posting Protocol to app-native and shell-invoked GitHub posts

### DIFF
--- a/copilot/copilot-instructions.md
+++ b/copilot/copilot-instructions.md
@@ -158,7 +158,16 @@ Never include the Co-authored-by trailer in PR titles, PR descriptions, issue bo
 
 ## GitHub Posting Protocol (MANDATORY)
 
-Before posting any GitHub content on my behalf - issue comments, PR comments, PR descriptions, review comments, review-thread replies, or issue creation (via `gh` CLI or GitHub MCP tools):
+Before posting any GitHub content on my behalf — issue comments, PR comments, PR descriptions, review comments, review-thread replies, or issue creation — regardless of mechanism. This fires for **any** of these, including when they appear inside a `bash`/shell call:
+
+- App-native tools, whatever the host calls them (e.g. `add_pr_review_comment`, `reply_to_comment`, submit-review, post-issue-comment, edit PR body).
+- GitHub MCP tools (`create_pull_request`, `update_pull_request`, comment tools).
+- CLI: `gh issue comment`, `gh pr comment`, `gh pr review`, `gh api …` POST/PATCH against `/issues/`, `/pulls/`, `/reviews`, `/comments`.
+- Raw REST/GraphQL via `curl`.
+
+Drafts count: if the tool stages content that will become a posted GitHub body (e.g. pending review comments the user will submit later), include the signature in the draft body.
+
+Then:
 
 - Append the required signature block at the very end of the body, separated by a blank line.
 - Do not include the `Co-authored-by` trailer; that trailer is only for git commit messages.


### PR DESCRIPTION
## Gap

The "GitHub Posting Protocol (MANDATORY)" section scoped itself with the parenthetical "(via `gh` CLI or GitHub MCP tools)". Agents using app-native posting tools (e.g. `add_pr_review_comment` for pending inline review drafts, `reply_to_comment` for thread replies, app-native submit-review) read that literally and skipped the signature block — observed in the Copilot Tauri app.

## Fix

Mirror the `pr-authoring` authoring-gate's host-agnostic language:

- Fire on any mechanism: app-native tools (host-agnostic), GitHub MCP, `gh` CLI, raw REST/GraphQL via `curl` — including when invoked through `bash`.
- Drafts count: if the tool stages content that will become a posted GitHub body, include the signature in the draft.

Symlink `~/.copilot/copilot-instructions.md → copilot/copilot-instructions.md` picks this up automatically; no resync needed.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 4.7) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>
