### PR TITLE
Add stacked-PR merge-mode guardrail to pr-merge-readiness

### DIFF
--- a/copilot/skills/pr-author/SKILL.md
+++ b/copilot/skills/pr-author/SKILL.md
@@ -114,6 +114,8 @@ When basing on a prior PR's head, add a line near the top of the PR body:
 
 Pass `--base <stacked-branch>` to `gh pr create`. After the upstream PR merges, retarget using an app-native PR edit tool if one is available (no `read:org` required). Only fall back to `gh pr edit <num> --base <default>` if no app-native tool is available, and expect the REST API fallback from [Edge cases](#edge-cases) if that errors on scopes.
 
+When this PR is later merged, see `pr-merge-readiness` for the stacked-PR merge-mode rule — do not squash a PR whose base isn't the default branch.
+
 ### 6. Draft the PR
 
 **Title:** Concise summary. Follow repo conventions if any (e.g., `feat:`, `fix:`).

--- a/copilot/skills/pr-merge-readiness/SKILL.md
+++ b/copilot/skills/pr-merge-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-merge-readiness
-description: Use when getting a pull request ready to merge by addressing review threads, CI failures, or conflicts, without performing the merge.
+description: Use when getting a pull request ready to merge by addressing review threads, CI failures, or conflicts, or when choosing a merge mode (squash, rebase, merge commit) for a PR — especially stacked PRs whose base is not the repo default branch.
 ---
 
 # PR Merge Readiness
@@ -97,6 +97,30 @@ Report:
 Tell the user the PR is ready to merge. **Stop.** Do not merge.
 
 If `mergeStateStatus` is `BLOCKED` because approval is missing, say so plainly and stop. That is a wait on a human, not something to work around.
+
+## Stacked-PR merge-mode guardrail
+
+This skill bars you from pressing merge. But sometimes the user explicitly authorizes the merge ("merge it", `gh pr merge --auto`, an auto-merge orchestration). Before any merge actually fires — through `gh pr merge`, an app-native merge tool, the GitHub MCP `merge_pull_request` tool, or `curl` against `/pulls/{n}/merge` — run the preflight and pick the right mode.
+
+**Preflight:**
+
+```bash
+GH_PAGER="" gh pr view <n> --repo <owner>/<repo> \
+  --json baseRefName,baseRepository
+```
+
+Compare `baseRefName` to the repo's default branch (`baseRepository.defaultBranchRef.name`, or `gh repo view --json defaultBranchRef`).
+
+**Rule:**
+
+- `baseRefName == default branch` → squash is the house style in many repos; `--squash` is fine when that's the repo's convention.
+- `baseRefName != default branch` → the PR is **stacked**. Do **not** squash.
+  - Prefer `--rebase` so the child's commits replay cleanly onto the parent.
+  - If the child branch has merged the default branch (or its parent) into itself during its work, even `--rebase` can fold the upstream delta back into the parent. In that case, cherry-pick only the child's own commits onto the parent branch by hand and push.
+
+Why this matters: squashing a stacked PR collapses every commit on the child — including any "merge main into branch" commits the child has absorbed — into one commit on the parent. The parent PR's diff balloons with files it had nothing to do with. A real failure of this: `gh pr merge 6303 --squash --auto --delete-branch` on a PR stacked on `tclem/massive-pr-perf-research` produced a single squash of 1,609 files / +287,757 / -48,552 that landed as noise on the parent planning PR.
+
+If you cannot determine the right mode, stop and ask. Do not guess.
 
 ## Common mistakes
 


### PR DESCRIPTION
## Why

I (Copilot) squash-merged a stacked PR ([github/github-app#6303](https://github.com/github/github-app/pull/6303), whose base was `tclem/massive-pr-perf-research`, not `main`) by reflex. The squash folded 1,609 files / +287,757 / -48,552 into one commit on the parent because the child branch had merged a recent `main` into itself during its work. That delta showed up as noise on the parent planning PR ([github/github-app#5172](https://github.com/github/github-app/pull/5172)).

No existing skill carried a stacked-PR merge-mode rule. `pr-merge-readiness` already covers merge-readiness work and explicitly bans pressing the green button — but when the user authorizes the merge (`gh pr merge --auto`, "merge it", auto-merge orchestrations), there was no guidance on _how_ to merge.

## What

**`pr-merge-readiness/SKILL.md`**
- Description now mentions "squash" and "stacked PRs" so the skill triggers on merge-mode questions, not just merge-readiness flows.
- New **Stacked-PR merge-mode guardrail** section with the `gh pr view --json baseRefName,baseRepository` preflight and the rule: `baseRefName == default` → squash is fine; `baseRefName != default` → do not squash, prefer `--rebase`, cherry-pick the child's own commits if the child has absorbed upstream commits.
- Covers all merge mechanisms: `gh pr merge`, app-native tools, GitHub MCP `merge_pull_request`, raw `curl`.

**`pr-author/SKILL.md`**
- One-line cross-reference next to the existing stacked-PR `--base` handling, pointing at the new guardrail.

I did not touch `pr-risk-check` — it covers deploy-time risk, not merge mechanics; a cross-ref didn't fit naturally.

## Companion

A separate PR in `github/github-app` qualifies the copilot-tauri "Squash merge for PRs" line so it doesn't read as universal.

## Verification

Skill is symlinked into `~/.copilot/skills/pr-merge-readiness/SKILL.md` and shows in the skill index. New keywords ("squash", "stacked PRs") in the description should make the skill fire on merge-mode questions.

Leaving this for your review — not merging.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 4.7) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>
