### PR TITLE
Revert stacked-PR merge-mode guardrail from pr-merge-readiness

### DIFF
--- a/copilot/skills/pr-author/SKILL.md
+++ b/copilot/skills/pr-author/SKILL.md
@@ -114,8 +114,6 @@ When basing on a prior PR's head, add a line near the top of the PR body:
 
 Pass `--base <stacked-branch>` to `gh pr create`. After the upstream PR merges, retarget using an app-native PR edit tool if one is available (no `read:org` required). Only fall back to `gh pr edit <num> --base <default>` if no app-native tool is available, and expect the REST API fallback from [Edge cases](#edge-cases) if that errors on scopes.
 
-When this PR is later merged, see `pr-merge-readiness` for the stacked-PR merge-mode rule — do not squash a PR whose base isn't the default branch.
-
 ### 6. Draft the PR
 
 **Title:** Concise summary. Follow repo conventions if any (e.g., `feat:`, `fix:`).

--- a/copilot/skills/pr-merge-readiness/SKILL.md
+++ b/copilot/skills/pr-merge-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-merge-readiness
-description: Use when getting a pull request ready to merge by addressing review threads, CI failures, or conflicts, or when choosing a merge mode (squash, rebase, merge commit) for a PR — especially stacked PRs whose base is not the repo default branch.
+description: Use when getting a pull request ready to merge by addressing review threads, CI failures, or conflicts, without performing the merge.
 ---
 
 # PR Merge Readiness
@@ -97,30 +97,6 @@ Report:
 Tell the user the PR is ready to merge. **Stop.** Do not merge.
 
 If `mergeStateStatus` is `BLOCKED` because approval is missing, say so plainly and stop. That is a wait on a human, not something to work around.
-
-## Stacked-PR merge-mode guardrail
-
-This skill bars you from pressing merge. But sometimes the user explicitly authorizes the merge ("merge it", `gh pr merge --auto`, an auto-merge orchestration). Before any merge actually fires — through `gh pr merge`, an app-native merge tool, the GitHub MCP `merge_pull_request` tool, or `curl` against `/pulls/{n}/merge` — run the preflight and pick the right mode.
-
-**Preflight:**
-
-```bash
-GH_PAGER="" gh pr view <n> --repo <owner>/<repo> \
-  --json baseRefName,baseRepository
-```
-
-Compare `baseRefName` to the repo's default branch (`baseRepository.defaultBranchRef.name`, or `gh repo view --json defaultBranchRef`).
-
-**Rule:**
-
-- `baseRefName == default branch` → squash is the house style in many repos; `--squash` is fine when that's the repo's convention.
-- `baseRefName != default branch` → the PR is **stacked**. Do **not** squash.
-  - Prefer `--rebase` so the child's commits replay cleanly onto the parent.
-  - If the child branch has merged the default branch (or its parent) into itself during its work, even `--rebase` can fold the upstream delta back into the parent. In that case, cherry-pick only the child's own commits onto the parent branch by hand and push.
-
-Why this matters: squashing a stacked PR collapses every commit on the child — including any "merge main into branch" commits the child has absorbed — into one commit on the parent. The parent PR's diff balloons with files it had nothing to do with. A real failure of this: `gh pr merge 6303 --squash --auto --delete-branch` on a PR stacked on `tclem/massive-pr-perf-research` produced a single squash of 1,609 files / +287,757 / -48,552 that landed as noise on the parent planning PR.
-
-If you cannot determine the right mode, stop and ask. Do not guess.
 
 ## Common mistakes
 


### PR DESCRIPTION
## What

Reverts [#5](https://github.com/tclem/dotfiles/pull/5). Removes the "Stacked-PR merge-mode guardrail" section and the description change from `pr-merge-readiness`, and the forward-reference line from `pr-author`. Both files return to their exact pre-#5 state.

## Why

`pr-merge-readiness` has one job: drive a PR to ready, then **stop before merge** — "the user owns the merge." The guardrail section contradicted that contract by teaching the agent how to *pick a merge mode and run the merge* (rebase vs. cherry-pick, push by hand). It also carried a heavy, hyper-specific war story.

Choosing a merge mode is a property of the unsupervised merge orchestration (`agent-merge`), which actually drives through merge. That skill is custom/app-native and isn't tracked in this repo, so the right move is to cut the guidance here rather than house it in a skill that explicitly stops short of merging.

## Verification

`git diff eeea6ff -- <both files>` is empty — the branch matches the pre-#5 baseline exactly.