### PR TITLE
Cut blackbird skill to the rules agents actually break

### DIFF
--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -31,7 +31,7 @@ Everything else is in `gh blackbird search --help`.
 
 ## Lexical ANDs every term
 
-A lexical query is not a prompt. A single bare term is already broad — it matches a file's **content** or its **path**, so `ingest_pipeline` finds `tests/ingest_pipeline.rs` even though the string appears nowhere inside it. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
+A lexical query is not a prompt. A single bare term is already broad — it matches a file's **content**, its **path**, or a **symbol** it defines, so `ingest_pipeline` finds `tests/ingest_pipeline.rs` and `Client::code_search` finds `src/client.rs`, though neither string appears in the file. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
 
 ```sh
 # Wrong — `getChangedFilesState` is a guess, and one bad term zeroes the result

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -26,7 +26,7 @@ Everything else is in `gh blackbird search --help`. Read that instead of guessin
 
 ## Lexical ANDs every term
 
-A lexical query is not a prompt. Every bare term must appear in the same file, so prose returns nothing:
+A lexical query is not a prompt. Every bare term is ANDed, so a result comes back only when *all* of them appear in the same file. Stacking terms you hope are related — a sentence, or just a bag of plausible-sounding identifiers — usually matches nothing:
 
 ```sh
 # Wrong — three unrelated identifiers ANDed, zero results, retries burn quota
@@ -42,7 +42,7 @@ Mode decision rule:
 
 - A concrete identifier, literal, path, or regex → **lexical**.
 - A name you already know → **`--symbol`**. Do not approximate it with a regex.
-- A sentence or a concept → **`--semantic`**. If you catch yourself writing prose into lexical, you wanted semantic.
+- A concept, or a question you can't name a token for → **`--semantic`**. If you're stacking terms because you aren't sure what you're looking for, that's the tell.
 
 None of these is `rg`. Falling back to a local grep is right when the repo is checked out and the scope is local — not when the question is a symbol, a concept, or spans repos you don't have.
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -9,7 +9,10 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 **Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept.
 
-Two limits, because the results look authoritative either way. Blackbird returns top-N ranked results, so never present them as exhaustive. And it indexes the **default branch only** — it cannot see your working tree, a feature branch, or an unmerged PR, so anything you are actively changing has to be checked with `rg`.
+Two things the results won't tell you about themselves:
+
+- They are **top-N ranked**, not every match. Never present them as exhaustive.
+- The index covers the **default branch only** — no working tree, no feature branch, no unmerged PR. Check anything you are actively changing with `rg`.
 
 ## Canonical invocations
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -5,7 +5,9 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 # Blackbird Search
 
-`gh blackbird` is a superset of grep for indexed GitHub code. Reach for it when the question is bigger than a local checkout: multiple repos, GitHub code-search qualifiers, language-aware symbol lookup, or vector search. It returns top-N ranked results, never every match — when you need exhaustiveness, clone and `rg`.
+`gh blackbird` is a superset of grep for indexed GitHub code: many repos at once, GitHub code-search qualifiers, language-aware symbol lookup, and vector search over embeddings.
+
+**Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept. Blackbird returns top-N ranked results, so never present them as exhaustive.
 
 ## Canonical invocations
 
@@ -20,9 +22,9 @@ gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
 gh blackbird search --symbol parse_url -R owner/name --for-llm
 ```
 
-`--for-llm` caps the response at 4000 tokens; a bare `--json` has no cap, so one broad query can flood context. Switch to `--json` only for the grep-style flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet` — lexical-only, and mutually exclusive with `--for-llm`), a different `--max-tokens`, or after a `--for-llm` run reports `results_incomplete: true`. Always pass one of the two: with no format flag you get whatever the TTY heuristic picks — `pretty` on a terminal, `oneline` when piped — and neither is capped.
+`--for-llm` caps the response at 4000 tokens; a bare `--json` has no cap, so one broad query can flood context. Switch to `--json` only for the grep-style flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet`, mutually exclusive with `--for-llm`), a different `--max-tokens`, or after a run reports `results_incomplete: true`. Always pass one of them — with no format flag the output depends on whether stdout is a TTY, and neither default is capped.
 
-Everything else is in `gh blackbird search --help`. Read that instead of guessing at flags; this skill does not mirror it.
+Everything else is in `gh blackbird search --help`.
 
 ## Lexical ANDs every term
 
@@ -36,7 +38,7 @@ gh blackbird search 'repositoryStateCache changesState diff' -R desktop/desktop 
 gh blackbird search 'repositoryStateCache' -R desktop/desktop --for-llm -n 10
 ```
 
-Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. If you have several candidate names and don't know which one exists, `OR` them into one query rather than running them in sequence. Bare multi-term AND is for narrowing a hit you already have, not for describing what you're looking for.
+Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. If you have several candidate names and don't know which exists, `OR` them into one query rather than running them in sequence. Bare multi-term AND is for narrowing a hit you already have, not for describing what you're looking for.
 
 Mode decision rule:
 
@@ -44,38 +46,31 @@ Mode decision rule:
 - A name you already know → **`--symbol`**. Do not approximate it with a regex.
 - A concept, or a question you can't name a token for → **`--semantic`**. If you're stacking terms because you aren't sure what you're looking for, that's the tell.
 
-None of these is `rg`. Falling back to a local grep is right when the repo is checked out and the scope is local — not when the question is a symbol, a concept, or spans repos you don't have.
-
 ## Scoping
 
-`-R owner/name` folds into the lexical query as a `repo:` qualifier — it is the same thing as writing `repo:owner/name` inline. **Use `-R`, always.** It is repeatable, it reads clearly, and it is the only form that scopes `--semantic`: semantic sends the query verbatim as the embedding prompt and builds its scoping filter from `-R` alone, so an inline `repo:` there is embedded as prompt text and silently filters nothing. Do not mix the two conventions.
+`-R owner/name` folds into the lexical query as a `repo:` qualifier — for lexical the two are identical. **Use `-R`.** It is also the only form that scopes `--semantic`, which sends your query verbatim as the embedding prompt and builds its filter from `-R` alone; an inline `repo:` there embeds as prompt text and filters nothing.
 
-Query cheaply; quotas are cost-based, with separate lexical and semantic buckets:
+Query cheaply; quotas are cost-based, and lexical and semantic have separate limits:
 
-1. If the repo is checked out and the scope is local, use `rg` instead.
-2. Scope before broadening: add `-R`, `path:`, `language:`, or a more distinctive literal before raising `-n`.
-3. Start at `-n 5` or `-n 10`. Raise it only after the first page proves the query is correctly scoped.
-4. `OR` is the cheap shape for a disjunction — one query beats N sequential ones for the same candidates. It turns expensive when the terms are *generic*: each one floods on its own and the union is noise. Distinctiveness decides, not the operator.
-5. Clip pathological lines with `-M 200` when results include minified or generated code.
-6. Stop once you have a canonical file, owner repo, route, or schema. Reading one result beats another broad search.
+1. Scope before broadening: add `-R`, `path:`, `language:`, or a more distinctive literal before raising `-n`.
+2. Start at `-n 5` or `-n 10`. Raise it only after the first page proves the query is correctly scoped.
+3. `OR` is the cheap shape for a disjunction — one query beats N sequential ones for the same candidates. It turns expensive when the terms are *generic*: each floods on its own and the union is noise. Distinctiveness decides, not the operator.
+4. Clip pathological lines with `-M 200` when results include minified or generated code.
+5. Stop once you have a canonical file, owner repo, route, or schema. Reading one result beats another broad search.
 
-Code search is case-insensitive, so `octokit` already finds `Octokit` — case variants are never worth a query. For genuine spelling variants, `OR` them into one query; do not fire them off as separate searches, sequentially or batched into one shell call behind `|| true`. Batching hides the cost without reducing it: it is still N queries against the same quota, where the `OR` is one.
+Code search is case-insensitive, so case variants are never worth a query: `octokit` already finds `Octokit`. `OR` genuine spelling variants into one query rather than firing separate searches — batching them into a single shell call behind `|| true` hides the cost without reducing it.
 
 ## Ownership discovery
 
-`--semantic` is single-repo, so it is a bad first move for "who owns X?" — a guessed repo returns plausible, irrelevant neighbors. Lexically search the proper noun, service name, route, or config key across likely repos first, identify the owner repo, then read its docs/README/routes. Use `--semantic` inside that repo only if the docs don't answer the concept.
+`--semantic` is single-repo, so it is a bad first move for "who owns X?" — a guessed repo returns plausible, irrelevant neighbors. Lexically search the proper noun, service name, route, or config key across likely repos, then read the owner repo's docs and routes. Use `--semantic` inside that repo only if the docs don't answer the concept.
 
 ## Caller tracing
 
-Blackbird is for callers in repos you don't have locally. For "did we get every caller," use `rg` on a checkout — never present ranked results as exhaustive.
-
-Real callers usually go through a wrapper, not the raw type. Start at the callee definition, find the generated client or SDK helper around it, and search **that** symbol. For an RPC endpoint, the fully-qualified names beat the bare ones: prefer `SomeService::Client.count`, `/twirp/example.v1.QueryAPI/Count`, or `Example::V1::CountRequest` over `CountRequest`. Check paths before concluding — tests, fakes, fixtures, and generated code look like callsites.
+Real callers usually go through a wrapper, not the raw type. Start at the callee definition, find the generated client or SDK helper around it, and search **that** symbol. For an RPC endpoint the fully-qualified names beat the bare ones: prefer `SomeService::Client.count`, `/twirp/example.v1.QueryAPI/Count`, or `Example::V1::CountRequest` over `CountRequest`. Check paths before concluding — tests, fakes, fixtures, and generated code all look like callsites.
 
 ## Rate limits
 
-A 429 means the bucket for that mode is exhausted; a semantic 429 says nothing about lexical quota. With `--json`, the error arrives as JSONL carrying `retry_after_seconds` and/or `rate_limit_reset_epoch_seconds`.
-
-Honor the metadata **once**: wait the stated interval plus a cushion, make the query cheaper (lower `-n`, tighter scope, split `OR`s), retry. If that also 429s or the wait is long, stop and tell the user — include the mode and the cheaper query you'd try next. Do not spin.
+A 429 means you have exhausted the rate limit for that mode; a semantic 429 says nothing about lexical quota. With `--json` the error arrives as JSONL carrying `retry_after_seconds` and/or `rate_limit_reset_epoch_seconds`. Honor it **once**: wait the stated interval plus a cushion, tighten the query, retry. If that also 429s or the wait is long, stop and tell the user — include the mode and the cheaper query you would try next. Do not spin.
 
 ## Rules
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -9,9 +9,7 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 **Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept.
 
-Two things the results won't tell you about themselves:
-
-- They are **top-N ranked**, not every match. Never present them as exhaustive.
+- Results are **top-N ranked**, not every match. Never present them as exhaustive.
 - The index covers the **default branch only** — no working tree, no feature branch, no unmerged PR. Check anything you are actively changing with `rg`.
 
 ## Canonical invocations

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -5,9 +5,7 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 # Blackbird Search
 
-`gh blackbird` is a superset of grep for indexed GitHub code: many repos at once, GitHub code-search qualifiers, language-aware symbol lookup, and vector search over embeddings.
-
-**Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept.
+`gh blackbird` is a superset of grep for indexed GitHub code. **Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept.
 
 - Results are **top-N ranked**, not every match. Never present them as exhaustive.
 - The index covers the **default branch only** — no working tree, no feature branch, no unmerged PR. Check anything you are actively changing with `rg`.
@@ -18,7 +16,7 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 # Agent default: token-capped JSONL (--for-llm == --max-tokens 4000 --format jsonl)
 gh blackbird search 'TokenResolver path:src/auth' -R owner/name --for-llm -n 10
 
-# Grep-style: explicit context + width clip. Mutually exclusive with --for-llm.
+# Grep-style: explicit context + width clip
 gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
 
 # Exact symbol lookup, language-aware
@@ -31,7 +29,7 @@ Everything else is in `gh blackbird search --help`.
 
 ## Lexical ANDs every term
 
-A lexical query is not a prompt. A single bare term is already broad — it matches a file's **content**, its **path**, or a **symbol** it defines, so `ingest_pipeline` finds `tests/ingest_pipeline.rs` and `Client::code_search` finds `src/client.rs`, though neither string appears in the file. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
+A lexical query is not a prompt. A single bare term is already broad — it matches a file's **content**, its **path**, or a **symbol** it defines, so it hits files that contain the string nowhere. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
 
 ```sh
 # Wrong — `getChangedFilesState` is a guess, and one bad term zeroes the result
@@ -47,13 +45,12 @@ To sharpen a term rather than add one, qualify it. `symbol:`, `def:`, `path:`, a
 
 Mode decision rule:
 
-- A concrete identifier, literal, path, or regex → **lexical**.
 - A name you already know → **`--symbol`**. Do not approximate it with a regex.
 - A concept, or a question you can't name a token for → **`--semantic`**. If you're stacking terms because you aren't sure what you're looking for, that's the tell.
 
 ## Scoping
 
-`-R owner/name` folds into the lexical query as a `repo:` qualifier — for lexical the two are identical. **Use `-R`.** It is also the only form that scopes `--semantic`, which sends your query verbatim as the embedding prompt and builds its filter from `-R` alone; an inline `repo:` there embeds as prompt text and filters nothing.
+`-R owner/name` folds into the lexical query as a `repo:` qualifier — for lexical the two are identical. **Use `-R`.** It is also the only form that scopes `--semantic`, where an inline `repo:` is embedded as prompt text and filters nothing.
 
 Query cheaply; quotas are cost-based, and lexical and semantic have separate limits:
 
@@ -65,21 +62,14 @@ Query cheaply; quotas are cost-based, and lexical and semantic have separate lim
 
 Code search is case-insensitive, so case variants are never worth a query: `octokit` already finds `Octokit`. `OR` genuine spelling variants into one query rather than firing separate searches — batching them into a single shell call behind `|| true` hides the cost without reducing it.
 
-## Ownership discovery
-
-`--semantic` is single-repo, so it is a bad first move for "who owns X?" — a guessed repo returns plausible, irrelevant neighbors. Lexically search the proper noun, service name, route, or config key across likely repos, then read the owner repo's docs and routes. Use `--semantic` inside that repo only if the docs don't answer the concept.
-
 ## Caller tracing
 
-Real callers usually go through a wrapper, not the raw type. Start at the callee definition, find the generated client or SDK helper around it, and search **that** symbol. For an RPC endpoint the fully-qualified names beat the bare ones: prefer `SomeService::Client.count`, `/twirp/example.v1.QueryAPI/Count`, or `Example::V1::CountRequest` over `CountRequest`. Check paths before concluding — tests, fakes, fixtures, and generated code all look like callsites.
-
-## Rate limits
-
-A 429 means you have exhausted the rate limit for that mode; a semantic 429 says nothing about lexical quota. With `--json` the error arrives as JSONL carrying `retry_after_seconds` and/or `rate_limit_reset_epoch_seconds`. Honor it **once**: wait the stated interval plus a cushion, tighten the query, retry. If that also 429s or the wait is long, stop and tell the user — include the mode and the cheaper query you would try next. Do not spin.
+Real callers usually go through a wrapper, not the raw type. Start at the callee definition, find the generated client or SDK helper around it, and search **that** symbol. For an RPC endpoint, fully-qualified names beat bare ones: `Example::V1::CountRequest` over `CountRequest`. Check paths before concluding — tests, fakes, fixtures, and generated code all look like callsites.
 
 ## Rules
 
-- `--semantic` accepts at most one `-R`; lexical accepts many.
+- `--semantic` accepts at most one `-R`; lexical accepts many. Don't start semantic in a guessed repo — find the owner repo lexically first.
+- On a 429, honor the error's `retry_after_seconds` once with a cheaper query, then stop and report. Lexical and semantic limits are separate.
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
 - Supported hosts are `github.com` and Proxima data-residency tenants (`<tenant>.ghe.com`). Self-hosted GHES is out of scope — that hostname fails with `UnsupportedHost` before a request is made.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -7,8 +7,6 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 `gh blackbird` is a superset of grep for indexed GitHub code. Reach for it when the question is bigger than a local checkout: multiple repos, GitHub code-search qualifiers, language-aware symbol lookup, or vector search. It returns top-N ranked results, never every match — when you need exhaustiveness, clone and `rg`.
 
-User-level skill. Do not mirror it into a project repo.
-
 ## Canonical invocations
 
 ```sh

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -20,7 +20,7 @@ gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
 gh blackbird search --symbol parse_url -R owner/name --for-llm
 ```
 
-`--for-llm` is the default because it bounds response size; a bare `--json` has no token cap and one broad query can flood context. Reach for `--json` only when you need the grep-style flags, a non-4000 `--max-tokens`, or a previous `--for-llm` run returned `results_incomplete: true`. Never parse `pretty`.
+`--for-llm` caps the response at 4000 tokens; a bare `--json` has no cap, so one broad query can flood context. Switch to `--json` only for the grep-style flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet` — lexical-only, and mutually exclusive with `--for-llm`), a different `--max-tokens`, or after a `--for-llm` run reports `results_incomplete: true`. Always pass one of the two: with no format flag you get whatever the TTY heuristic picks — `pretty` on a terminal, `oneline` when piped — and neither is capped.
 
 Everything else is in `gh blackbird search --help`. Read that instead of guessing at flags; this skill does not mirror it.
 
@@ -81,6 +81,5 @@ Honor the metadata **once**: wait the stated interval plus a cushion, make the q
 
 - `--semantic` accepts at most one `-R`; lexical accepts many.
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
-- `-A`/`-B`/`-C`/`-M`/`--full-snippet` are lexical-only and mutually exclusive with `--for-llm`. Pick the LLM mode or the grep-style mode, not both.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
 - `--fileset` (a client-ingested corpus, searched instead of GitHub-indexed repos) is dotcom only. Normal lexical and semantic search work fine against `*.ghe.com`.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -30,17 +30,19 @@ Everything else is in `gh blackbird search --help`.
 
 ## Lexical ANDs every term
 
-A lexical query is not a prompt. Every bare term is ANDed, so a result comes back only when *all* of them appear in the same file. Stacking terms you hope are related — a sentence, or just a bag of plausible-sounding identifiers — usually matches nothing:
+A lexical query is not a prompt. A single bare term is already broad — it ORs across three domains, matching the file's **path**, its **content**, or a **symbol** name. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
 
 ```sh
-# Wrong — three unrelated identifiers ANDed, zero results, retries burn quota
-gh blackbird search 'repositoryStateCache changesState diff' -R desktop/desktop --json -n 10
+# Wrong — `getChangedFilesState` is a guess, and one bad term zeroes the result
+gh blackbird search 'repositoryStateCache getChangedFilesState' -R desktop/desktop --for-llm -n 10
 
 # Right — one distinctive identifier, then read the file it lands in
 gh blackbird search 'repositoryStateCache' -R desktop/desktop --for-llm -n 10
 ```
 
 Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. If you have several candidate names and don't know which exists, `OR` them into one query rather than running them in sequence. Bare multi-term AND is for narrowing a hit you already have, not for describing what you're looking for.
+
+To sharpen a term rather than add one, qualify it. `symbol:`, `def:`, `path:`, and `content:` each scope to a single domain and accept a regex, so `def:RepositoryStateCache` finds the definition where the bare term returns every file that mentions it. A bare `/regex/` searches content only.
 
 Mode decision rule:
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -79,4 +79,3 @@ A 429 means you have exhausted the rate limit for that mode; a semantic 429 says
 - `--semantic` accepts at most one `-R`; lexical accepts many.
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
-- `--fileset` (external, client-ingested corpora) is dotcom only.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -81,7 +81,7 @@ Honor the metadata **once**: wait the stated interval plus a cushion, make the q
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
 - `-A`/`-B`/`-C`/`-M`/`--full-snippet` are lexical-only and mutually exclusive with `--for-llm`. Pick the LLM mode or the grep-style mode, not both.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
-- No GHES. `--fileset` searches a client-ingested corpus instead of GitHub-indexed repos, and is dotcom only — do not call it against `*.ghe.com`.
+- `--fileset` (a client-ingested corpus, searched instead of GitHub-indexed repos) is dotcom only. Normal lexical and semantic search work fine against `*.ghe.com`.
 - Do not pass `--lab` (staff-only, currently defaulted on anyway).
 
 ## Common mistakes

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -5,173 +5,93 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 # Blackbird Search
 
-`gh blackbird` is a superset of grep for indexed GitHub code. Use it when the question is bigger than a local checkout: multi-repo scope, GitHub code-search qualifiers (`language:`, `path:`, `symbol:`), language-aware symbol lookup, or vector search over embeddings. If the needed repos are checked out locally and the task is exhaustive, use `rg`.
+`gh blackbird` is a superset of grep for indexed GitHub code. Reach for it when the question is bigger than a local checkout: multiple repos, GitHub code-search qualifiers, language-aware symbol lookup, or vector search. It returns top-N ranked results, never every match — when you need exhaustiveness, clone and `rg`.
 
-## Not exhaustive
+User-level skill. Do not mirror it into a project repo.
 
-`gh blackbird` is more like Google than grep: it returns top-ranked results capped by `-n` (defaults 25 lexical, 10 semantic), not every match. Treat output as a ranked sample, never as a complete set. **If you need every occurrence - for a refactor, a security sweep, a "did we miss any callers" check - clone the repo and use `rg` on the checkout.** That is the only tool that promises exhaustiveness here.
+## Canonical invocations
 
-## When to use
+```sh
+# Agent default: token-capped JSONL (--for-llm == --max-tokens 4000 --format jsonl)
+gh blackbird search 'TokenResolver path:src/auth' -R owner/name --for-llm -n 10
 
-- Multiple repos in one query, no cloning.
-- "Where is symbol X defined?" or "where are likely callers?" - language-aware search beats regex for discovery.
-- Ownership discovery: "where does X live?", "which repo owns X?", "how do clients integrate with X?"
-- Conceptual / natural-language questions ("how does token resolution work in service Y?") - vector search over embeddings, not pattern matching.
-- Lexical queries that benefit from GitHub code-search qualifiers (`language:rust`, `path:**/migrations/`, `symbol:Foo`, `repo:owner/name`).
-- Broad lexical queries on large local repos where ranked discovery is enough and Blackbird's index beats a cold `rg` scan.
-- Need JSON output for programmatic consumption / piping to `jq`.
+# Grep-style: explicit context + width clip. Mutually exclusive with --for-llm.
+gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
 
-Not for:
+# Exact symbol lookup, language-aware
+gh blackbird search --symbol parse_url -R owner/name --for-llm
+```
 
-- Exhaustive enumeration. Use `rg` on a checkout when you need *every* match (refactors, security sweeps, "did we miss any callers"). See *Not exhaustive* above.
-- Tiny repos or narrow queries on a local checkout where an `rg` round-trip beats a network call.
-- Filesystem-aware work `rg` is good at (binary heuristics, hidden files, `--vimgrep` piping into an editor).
-- GHES hosts. External filesets are dotcom only - do not call them against `*.ghe.com`.
+`--for-llm` is the default because it bounds response size; a bare `--json` has no token cap and one broad query can flood context. Reach for `--json` only when you need the grep-style flags, a non-4000 `--max-tokens`, or a previous `--for-llm` run returned `results_incomplete: true`. Never parse `pretty`.
 
-## Mode picker
+Everything else is in `gh blackbird search --help`. Read that instead of guessing at flags; this skill does not mirror it.
 
-- **Lexical** - you know the string or regex. Use the GitHub code-search query syntax.
-- **`--symbol`** - you know the name. Language-aware; do not approximate with regex.
-- **`--semantic`** - you only know the concept. Vector search over embeddings; single repo; returns nearest neighbors, not an exhaustive set.
+## Lexical ANDs every term
 
-## Query efficiency
+A lexical query is not a prompt. Every bare term must appear in the same file, so prose returns nothing:
 
-Blackbird quotas are cost-based, not just request-count based. Lexical and semantic have separate quota buckets, and expensive queries consume more quota. Treat every broad search as spending a shared budget.
+```sh
+# Wrong — three unrelated identifiers ANDed, zero results, retries burn quota
+gh blackbird search 'repositoryStateCache changesState diff' -R desktop/desktop --json -n 10
 
-Use the cheapest useful query first:
+# Right — one distinctive identifier, then read the file it lands in
+gh blackbird search 'repositoryStateCache' -R desktop/desktop --for-llm -n 10
+```
 
-1. Prefer local `rg` when the repo is already checked out and the scope is local.
-2. Prefer lexical discovery over semantic when you have concrete identifiers, strings, paths, routes, docs names, config keys, package names, or repo names.
-3. Prefer `--symbol` for exact name lookup instead of broad lexical regexes.
-4. Scope before broadening: add `-R owner/repo`, `path:`, `language:`, package/service names, or a distinctive quoted string before increasing `-n`.
-5. Start with a small cap (`-n 5` or `-n 10`) for discovery. Increase only if the first page proves the query is correctly scoped and still lacks the needed evidence.
-6. Avoid broad `OR` queries across large repos as a first move. Split them into narrower searches so one expensive term does not burn quota and flood output.
-7. Do not run lexical and semantic back-to-back "just in case." Pick one mode from the evidence, then switch only when the result shows the mode is wrong.
-8. Use `--for-llm` by default when an agent is parsing the output; it bounds response size so a single broad query can't flood context.
-9. Clip pathological snippets with `-M N` (e.g. `-M 200`) when results include minified JS, generated code, or other very long lines.
-10. Stop searching once you have a canonical file, owner repo, route, schema, doc, or wrapper symbol to read. Reading one result is cheaper and more reliable than another broad search.
+Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. Multi-term lexical is for narrowing a known-good hit, not for describing what you're looking for.
 
-If a query returns noisy results, make it cheaper before retrying: lower `-n`, add repo/path/language qualifiers, add `-M` to clip long lines, search a more distinctive literal, or search the wrapper/symbol that appeared in the first results.
+Mode decision rule:
 
-## Discovery before semantic
+- A concrete identifier, literal, path, or regex → **lexical**.
+- A name you already know → **`--symbol`**. Do not approximate it with a regex.
+- A sentence or a concept → **`--semantic`**. If you catch yourself writing prose into lexical, you wanted semantic.
 
-For ambiguous cross-repo questions, first find the owner repo/component. If the user asks "how do I integrate with X's API?" or "where does X live?", do **lexical discovery** for proper nouns, service names, repo names, docs references, config keys, routes, or schema names across likely repos/orgs before semantic search.
+## Scoping
 
-Semantic search is good for "within this repo, explain this concept." It is a poor first move for "find the repo/component that owns this concept" because `--semantic` is single-repo scoped and searching the wrong repo returns plausible but irrelevant neighbors.
+`-R owner/name` folds into the lexical query as a `repo:` qualifier — it is the same thing as writing `repo:owner/name` inline. **Use `-R`, always.** It is repeatable, it reads clearly, and it is the only form that scopes `--semantic`: semantic sends the query verbatim as the embedding prompt and builds its scoping filter from `-R` alone, so an inline `repo:` there is embedded as prompt text and silently filters nothing. Do not mix the two conventions.
 
-Example progression for "How do I integrate with Octokit authentication?":
+Query cheaply; quotas are cost-based, with separate lexical and semantic buckets:
 
-1. Lexical discovery: search `octokit authentication` in likely repos such as `octokit/octokit.rb`, `octokit/rest.js`, or broader org scope if available.
-2. Inspect hits for the canonical owner repo, docs, routes, schema, or README references.
-3. Once the owner repo is identified, read docs/README/routes/schema files first.
-4. Lexical-search auth/API terms inside the owner repo: `JWT`, `token`, `Authorization`, `GraphQL`, `curl`.
-5. Use semantic search inside the owner repo only if docs are absent or the conceptual flow remains unclear.
-6. Use symbol search only after concrete class/module/function names appear.
+1. If the repo is checked out and the scope is local, use `rg` instead.
+2. Scope before broadening: add `-R`, `path:`, `language:`, or a more distinctive literal before raising `-n`.
+3. Start at `-n 5` or `-n 10`. Raise it only after the first page proves the query is correctly scoped.
+4. Split broad `OR` queries into narrower ones. A five-term `OR` across a large repo is one expensive query that also floods output.
+5. Clip pathological lines with `-M 200` when results include minified or generated code.
+6. Stop once you have a canonical file, owner repo, route, or schema. Reading one result beats another broad search.
 
-After finding a likely canonical doc, route file, schema, or README, stop broad search and read it. Do not keep searching when the answer surface has been found.
+Code search is case-insensitive: `octokit` already finds `Octokit`. Do not fire off case or spelling variants of the same query — not sequentially, and not batched into one shell call behind `|| true`. Batching hides the cost; it is still N queries against the same quota. Run one query, read the result, then decide.
+
+## Ownership discovery
+
+`--semantic` is single-repo, so it is a bad first move for "who owns X?" — a guessed repo returns plausible, irrelevant neighbors. Lexically search the proper noun, service name, route, or config key across likely repos first, identify the owner repo, then read its docs/README/routes. Use `--semantic` inside that repo only if the docs don't answer the concept.
 
 ## Caller tracing
 
-"Who calls X?", "all callers of X?", and "what is causing this call in production?" are caller-enumeration tasks. Use `gh blackbird` for discovery across repos you do not have locally. If the relevant repo is checked out, use local `rg` for exhaustive caller work.
+Blackbird is for callers in repos you don't have locally. For "did we get every caller," use `rg` on a checkout — never present ranked results as exhaustive.
 
-Caller tracing ladder:
+Real callers usually go through a wrapper, not the raw type. Start at the callee definition, find the generated client or SDK helper around it, and search **that** symbol. For an RPC endpoint, the fully-qualified names beat the bare ones: prefer `SomeService::Client.count`, `/twirp/example.v1.QueryAPI/Count`, or `Example::V1::CountRequest` over `CountRequest`. Check paths before concluding — tests, fakes, fixtures, and generated code look like callsites.
 
-1. Start at the callee definition: proto method, interface, endpoint, route, or function.
-2. Identify generated clients, wrappers, SDK helpers, or service-specific abstractions around that call.
-3. Search the wrapper method first; real callers often use `Client.search` or `ApiClient#do_request`, not the raw request type.
-4. Search direct usage next: request/response types, generated client methods, concrete HTTP/Twirp/gRPC paths, endpoint strings.
-5. Separate production callsites from tests, fakes, fixtures, generated code, and docs.
-6. For operational questions, use code search to enumerate possible callers, then telemetry/logs/metrics to rank active production callers.
+## Rate limits
 
-For service/RPC endpoints, search all of these when available:
+A 429 means the bucket for that mode is exhausted; a semantic 429 says nothing about lexical quota. With `--json`, the error arrives as JSONL carrying `retry_after_seconds` and/or `rate_limit_reset_epoch_seconds`.
 
-- Proto or IDL method name.
-- Generated client method.
-- Concrete HTTP/Twirp/gRPC path.
-- Language-specific wrapper names.
-- Fully-qualified request/response type names.
-
-Generic names create false positives. Scope aggressively with repo/org plus package/API names and inspect paths before drawing conclusions. Prefer `SomeService::Client.count`, `/twirp/example.v1.QueryAPI/Count`, or `Example::V1::CountRequest` over a bare `CountRequest`.
-
-Once a wrapper is identified, stop broad search and search that wrapper symbol/string. Wrapper callers are usually the real integration points.
-
-## Output for agents
-
-Three output tiers, in order of preference for agent use:
-
-1. **`--for-llm`** - default for agents. Sugar for `--max-tokens 4000 --format jsonl`: server picks high-density regions under a token budget and emits JSONL. Use this whenever an agent will consume the output.
-2. **`--json`** (= `--format jsonl`) - JSONL without the token cap. Use when you specifically need grep-style snippet control (`-A`/`-B`/`-C`/`-M`/`--full-snippet`), a non-4000 `--max-tokens N` budget, or the response set the `results_incomplete: true` meta flag on a previous `--for-llm` run of the same query. Don't switch pre-emptively "in case results are too short."
-3. **`pretty`** - humans only. Never grep or parse it.
-
-`--for-llm` and the grep-style snippet flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet`) are mutually exclusive — the LLM mode picks its own dense regions, so you choose one strategy or the other:
-
-- **Token-budgeted** (`--for-llm`): let the server decide what's relevant. Best default.
-- **Grep-style** (`--json` + `-C N` / `-M N` / `--full-snippet`): explicit line context and width clipping. Use when you need predictable surrounding lines or to clip minified/generated lines from blowing context. These flags affect JSONL output as of v0.2.0 ([#14](https://github.com/github/gh-blackbird/pull/14)).
-
-```sh
-# Default agent invocation: token-capped JSONL
-gh blackbird search 'TokenResolver language:rust path:src/auth' -R owner/name --for-llm
-
-# Grep-style: explicit context + width clip (requires --json, not --for-llm)
-gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
-
-# Exact symbol lookup (language-aware)
-gh blackbird search --symbol parse_url -R owner/name --for-llm
-
-# Semantic / conceptual (single repo, may need indexing)
-gh blackbird search --semantic "how does token resolution work" -R owner/name --auto-index --for-llm -n 5
-
-# External fileset (dotcom only)
-gh blackbird search 'pattern' --fileset my-corpus --for-llm -n 10
-
-# Custom token budget (overrides --for-llm's 4000)
-gh blackbird search 'pattern' -R owner/name --json --max-tokens 8000
-```
-
-Cap results with `-n` when scoping a broad query. Defaults: 25 lexical, 10 semantic. For agent discovery, prefer `-n 5` or `-n 10` unless you already know the query is narrow.
-
-## Rate limits and retries
-
-429s mean the current quota bucket is exhausted or the query spent too much of it. Because lexical and semantic have different cost buckets, do not assume a semantic retry tells you anything about lexical quota, or vice versa.
-
-When using `--json`, errors are JSONL too:
-
-```json
-{"type":"error","code":"rate_limited","status":429,"retry_after_seconds":30,"rate_limit_reset_epoch_seconds":1778990400,"guidance":"Back off before retrying; honor retry_after_seconds or rate_limit_reset_epoch_seconds when present."}
-```
-
-Handle 429s deliberately:
-
-1. If `retry_after_seconds` is present and short enough to wait in the current tool run, wait that long plus a small cushion, then retry once.
-2. If only `rate_limit_reset_epoch_seconds` is present and the reset is soon, wait until reset plus a small cushion, then retry once.
-3. Before retrying, make the query cheaper unless the exact same query is necessary: reduce `-n`, add `-R`/`path:`/`language:`, split broad `OR`s, or switch from semantic to lexical when you have concrete terms.
-4. If the wait is long, the reset time is missing, or the retry also returns 429, stop and tell the user the query hit Blackbird rate limits. Include the mode (lexical or semantic), any retry/reset value, and the cheaper query you would try next.
-5. Do not spin on 429s. One intentional retry is enough for an agent unless the user explicitly asks to keep waiting.
+Honor the metadata **once**: wait the stated interval plus a cushion, make the query cheaper (lower `-n`, tighter scope, split `OR`s), retry. If that also 429s or the wait is long, stop and tell the user — include the mode and the cheaper query you'd try next. Do not spin.
 
 ## Rules
 
-- Default agent invocation is `--for-llm` (token-capped JSONL). Drop to `--json` only when (a) you need grep-style snippet flags `-A`/`-B`/`-C`/`-M`/`--full-snippet`, which are mutually exclusive with `--for-llm`; (b) a previous `--for-llm` run on the same query returned `results_incomplete: true`; or (c) you need a specific non-4000 `--max-tokens` budget. Never grep `pretty`.
-- `--semantic` accepts at most one `-R`. Lexical accepts many.
-- Pair `--semantic` with `--auto-index` against repos that may not be indexed yet, otherwise expect a 404.
-- Use `--symbol` for name lookup; do not regex around it.
-- Use `--semantic` for conceptual questions only after the repo scope is known; do not lexical-search a paraphrase inside a known repo when semantic would answer the concept better.
-- For ownership discovery, lexical-search proper nouns and concrete identifiers first. Do not start with semantic in a guessed repo.
-- For "all callers" questions, use local `rg` on checked-out repos whenever possible. Do not present ranked Blackbird results as exhaustive.
-- Spend quota intentionally: start narrow and low-`-n`, then broaden only when the first results justify it.
-- On JSONL errors with `code=="rate_limited"`, honor retry/reset metadata once; otherwise report the rate limit instead of looping.
-- Do not duplicate case variants unless the first result suggests case matters; code search for `octokit` can already find `Octokit`.
-- Prefer simple `jq` one-liners or reading key files over opaque ad-hoc post-processing. Avoid Python summarizers unless there is a real need.
-- Do not pass `--lab` (staff-only no-op).
-- No GHES. No filesets on `*.ghe.com`.
-- Snippet context (`-C/-A/-B`, `--full-snippet`) and width clipping (`-M`) work with `--json` JSONL output as of v0.2.0, but are mutually exclusive with `--for-llm`. Pick the LLM mode or the grep-style mode, not both.
+- `--semantic` accepts at most one `-R`; lexical accepts many.
+- Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
+- `-A`/`-B`/`-C`/`-M`/`--full-snippet` are lexical-only and mutually exclusive with `--for-llm`. Pick the LLM mode or the grep-style mode, not both.
+- Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
+- No GHES. `--fileset` searches a client-ingested corpus instead of GitHub-indexed repos, and is dotcom only — do not call it against `*.ghe.com`.
+- Do not pass `--lab` (staff-only, currently defaulted on anyway).
 
 ## Common mistakes
 
+- **Passing prose to lexical search** and reading the empty result as "not in this repo."
+- **Batching case or spelling variants** into one shell call, which spends the same quota as running them one at a time.
 - **Reaching for `rg` reflexively** when the right tool is `--symbol`, `--semantic`, or a cross-repo lexical query.
-- **Approximating symbol search with a regex** when `--symbol` exists.
-- **Starting semantic search in a guessed repo** when the real task is ownership discovery — find the owner repo lexically first.
-- **Continuing broad search after finding the canonical doc/route/schema/README.** Read it instead of running another query.
-- **Searching only raw request types** and missing the wrapper methods production callers actually use.
-- **Claiming "all callers"** from top-N Blackbird results without falling back to local `rg` or another exhaustive source.
-- **Retrying a 429 immediately**, repeatedly, or with the same expensive query when retry/reset metadata says to wait.
-- **Treating Blackbird results as exhaustive** in any mode — it is top-N ranked, not every match.
+- **Starting semantic search in a guessed repo** when the task is ownership discovery.
+- **Continuing broad search after finding the canonical doc, route, or schema.** Read it.
+- **Searching only raw request types** and missing the wrappers production callers actually use.
+- **Claiming "all callers"** from top-N results without falling back to `rg`.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -81,3 +81,4 @@ A 429 means you have exhausted the rate limit for that mode; a semantic 429 says
 - `--semantic` accepts at most one `-R`; lexical accepts many.
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
+- Supported hosts are `github.com` and Proxima data-residency tenants (`<tenant>.ghe.com`). Self-hosted GHES is out of scope — that hostname fails with `UnsupportedHost` before a request is made.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -31,7 +31,7 @@ Everything else is in `gh blackbird search --help`.
 
 ## Lexical ANDs every term
 
-A lexical query is not a prompt. A single bare term is already broad — it ORs across three domains, matching the file's **path**, its **content**, or a **symbol** name. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
+A lexical query is not a prompt. A single bare term is already broad — it matches a file's **content** or its **path**, so `ingest_pipeline` finds `tests/ingest_pipeline.rs` even though the string appears nowhere inside it. Multiple bare terms are ANDed, so each one you add is another filter the same file must satisfy. Guess one identifier wrong and the query silently returns nothing, which reads like "absent from this repo" rather than "I made that name up":
 
 ```sh
 # Wrong — `getChangedFilesState` is a guess, and one bad term zeroes the result

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -84,4 +84,3 @@ Honor the metadata **once**: wait the stated interval plus a cushion, make the q
 - `-A`/`-B`/`-C`/`-M`/`--full-snippet` are lexical-only and mutually exclusive with `--for-llm`. Pick the LLM mode or the grep-style mode, not both.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
 - `--fileset` (a client-ingested corpus, searched instead of GitHub-indexed repos) is dotcom only. Normal lexical and semantic search work fine against `*.ghe.com`.
-- Do not pass `--lab` (staff-only, currently defaulted on anyway).

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -36,7 +36,7 @@ gh blackbird search 'repositoryStateCache changesState diff' -R desktop/desktop 
 gh blackbird search 'repositoryStateCache' -R desktop/desktop --for-llm -n 10
 ```
 
-Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. Multi-term lexical is for narrowing a known-good hit, not for describing what you're looking for.
+Pick the **single most distinctive** token — the rarest identifier, string literal, route, or config key — and let the file it lands in supply the rest. If you have several candidate names and don't know which one exists, `OR` them into one query rather than running them in sequence. Bare multi-term AND is for narrowing a hit you already have, not for describing what you're looking for.
 
 Mode decision rule:
 
@@ -55,11 +55,11 @@ Query cheaply; quotas are cost-based, with separate lexical and semantic buckets
 1. If the repo is checked out and the scope is local, use `rg` instead.
 2. Scope before broadening: add `-R`, `path:`, `language:`, or a more distinctive literal before raising `-n`.
 3. Start at `-n 5` or `-n 10`. Raise it only after the first page proves the query is correctly scoped.
-4. Split broad `OR` queries into narrower ones. A five-term `OR` across a large repo is one expensive query that also floods output.
+4. `OR` is the cheap shape for a disjunction — one query beats N sequential ones for the same candidates. It turns expensive when the terms are *generic*: each one floods on its own and the union is noise. Distinctiveness decides, not the operator.
 5. Clip pathological lines with `-M 200` when results include minified or generated code.
 6. Stop once you have a canonical file, owner repo, route, or schema. Reading one result beats another broad search.
 
-Code search is case-insensitive: `octokit` already finds `Octokit`. Do not fire off case or spelling variants of the same query — not sequentially, and not batched into one shell call behind `|| true`. Batching hides the cost; it is still N queries against the same quota. Run one query, read the result, then decide.
+Code search is case-insensitive, so `octokit` already finds `Octokit` — case variants are never worth a query. For genuine spelling variants, `OR` them into one query; do not fire them off as separate searches, sequentially or batched into one shell call behind `|| true`. Batching hides the cost without reducing it: it is still N queries against the same quota, where the `OR` is one.
 
 ## Ownership discovery
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -44,6 +44,8 @@ Mode decision rule:
 - A name you already know → **`--symbol`**. Do not approximate it with a regex.
 - A sentence or a concept → **`--semantic`**. If you catch yourself writing prose into lexical, you wanted semantic.
 
+None of these is `rg`. Falling back to a local grep is right when the repo is checked out and the scope is local — not when the question is a symbol, a concept, or spans repos you don't have.
+
 ## Scoping
 
 `-R owner/name` folds into the lexical query as a `repo:` qualifier — it is the same thing as writing `repo:owner/name` inline. **Use `-R`, always.** It is repeatable, it reads clearly, and it is the only form that scopes `--semantic`: semantic sends the query verbatim as the embedding prompt and builds its scoping filter from `-R` alone, so an inline `repo:` there is embedded as prompt text and silently filters nothing. Do not mix the two conventions.
@@ -83,13 +85,3 @@ Honor the metadata **once**: wait the stated interval plus a cushion, make the q
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
 - `--fileset` (a client-ingested corpus, searched instead of GitHub-indexed repos) is dotcom only. Normal lexical and semantic search work fine against `*.ghe.com`.
 - Do not pass `--lab` (staff-only, currently defaulted on anyway).
-
-## Common mistakes
-
-- **Passing prose to lexical search** and reading the empty result as "not in this repo."
-- **Batching case or spelling variants** into one shell call, which spends the same quota as running them one at a time.
-- **Reaching for `rg` reflexively** when the right tool is `--symbol`, `--semantic`, or a cross-repo lexical query.
-- **Starting semantic search in a guessed repo** when the task is ownership discovery.
-- **Continuing broad search after finding the canonical doc, route, or schema.** Read it.
-- **Searching only raw request types** and missing the wrappers production callers actually use.
-- **Claiming "all callers"** from top-N results without falling back to `rg`.

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -7,7 +7,9 @@ description: 'Use when reaching for `gh blackbird` (Blackbird code search) for c
 
 `gh blackbird` is a superset of grep for indexed GitHub code: many repos at once, GitHub code-search qualifiers, language-aware symbol lookup, and vector search over embeddings.
 
-**Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept. Blackbird returns top-N ranked results, so never present them as exhaustive.
+**Blackbird or `rg`?** `rg` when the repo is checked out *and* you need every occurrence — refactors, security sweeps, "did we miss a caller." Blackbird for everything else: repos you don't have, a symbol, a concept.
+
+Two limits, because the results look authoritative either way. Blackbird returns top-N ranked results, so never present them as exhaustive. And it indexes the **default branch only** — it cannot see your working tree, a feature branch, or an unmerged PR, so anything you are actively changing has to be checked with `rg`.
 
 ## Canonical invocations
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -25,7 +25,7 @@ gh blackbird search 'parseURL' -R a/b -R c/d --json -C 3 -M 200
 gh blackbird search --symbol parse_url -R owner/name --for-llm
 ```
 
-`--for-llm` caps the response at 4000 tokens; a bare `--json` has no cap, so one broad query can flood context. Switch to `--json` only for the grep-style flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet`, mutually exclusive with `--for-llm`), a different `--max-tokens`, or after a run reports `results_incomplete: true`. Always pass one of them — with no format flag the output depends on whether stdout is a TTY, and neither default is capped.
+`--for-llm` caps the response at 4000 tokens; a bare `--json` has no cap, so one broad query can flood context. Switch to `--json` only for the grep-style flags (`-A`/`-B`/`-C`/`-M`/`--full-snippet`, mutually exclusive with `--for-llm`), a different `--max-tokens`, or after a run reports `results_incomplete: true`. Always pass one explicitly rather than relying on the default, which varies with whether stdout is a TTY.
 
 Everything else is in `gh blackbird search --help`.
 

--- a/copilot/skills/blackbird/SKILL.md
+++ b/copilot/skills/blackbird/SKILL.md
@@ -77,4 +77,4 @@ A 429 means you have exhausted the rate limit for that mode; a semantic 429 says
 - `--semantic` accepts at most one `-R`; lexical accepts many.
 - Pair `--semantic` with `--auto-index` on repos that may not be indexed yet, or expect a 404.
 - Prefer `jq` one-liners or reading the file over ad-hoc post-processing scripts.
-- `--fileset` (a client-ingested corpus, searched instead of GitHub-indexed repos) is dotcom only. Normal lexical and semantic search work fine against `*.ghe.com`.
+- `--fileset` (external, client-ingested corpora) is dotcom only.


### PR DESCRIPTION
An audit of ~200 real `gh blackbird search` invocations across ~25 past agent sessions showed the skill losing the fight below roughly line 100. Rule #1 — "default agent invocation is `--for-llm`" — was ignored 6:1 (`--json` 113 uses vs `--for-llm` 18). The case-variant rule was routed around by batching four spellings into one shell call behind `|| true`. Agents ran `--help` 14 times mid-task despite the skill carrying a flag catalog. Length was the problem: everything competing for the same attention budget meant the rules near the bottom weren't reaching the reader.

The highest-frequency real failure wasn't in the skill at all. Agents stack terms they hope are related and lexical ANDs every one of them, so a single wrong guess silently returns nothing — which reads as "absent from this repo" rather than "I made that name up." That's now its own section above the fold, with a sharpened mode picker to catch it at write time.

Two other gaps closed. `-R` and an in-query `repo:` are the same thing for lexical, which nothing said, so agents mixed conventions within a session; `-R` is now the convention, and it's the only form that scopes semantic, where an inline `repo:` silently filters nothing. And the flag catalog is gone — it duplicated `--help`, went stale, and lost to the real thing anyway.

Review turned up two inherited claims that were wrong. "Split broad `OR` queries into narrower ones" contradicted the batching rule two lines below it: N sequential queries cost N regardless of packaging, so a disjunction over distinctive terms should be one `OR`. And "No GHES. No filesets on `*.ghe.com`." read as one blanket prohibition when it was two separate true facts — `*.ghe.com` is Proxima, not GHES, and the host rule is now stated directly, with the `UnsupportedHost` failure named so it's recognizable.

Behavioral claims were verified against a live index rather than inferred from source, after two source-reading detours landed on the wrong service. A bare term matches a file's content, its path, *or* a symbol it defines — `Client::code_search` returns `src/client.rs`, a string that appears in no file's content and no path. That also made the `path:`/`content:`/`symbol:`/`def:` qualifiers worth documenting; `def:` resolves to a definition where a bare term returns everything that mentions it.

Everything else was compressed against one test — does this change behavior, or does it read as background? "Use `rg` on a checkout" appeared four times across three sections; it's one two-sided rule and now sits in the intro, alongside the two ways results mislead: they're top-N ranked, and they cover the default branch only, so nothing on your working tree or an unmerged PR is visible. Rate limits and ownership discovery became one rule each — the 429 payload already carries its own guidance field.

177 lines → 75.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 5) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>