### PR TITLE
Cap sccache disk usage at 60 GiB

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -229,7 +229,7 @@ export RUST_BACKTRACE=1
 # Incremental compilation fights sccache's caching model — disable it so more
 # artifacts are cacheable.
 export CARGO_INCREMENTAL=0
-export SCCACHE_CACHE_SIZE="100G"
+export SCCACHE_CACHE_SIZE="60G"
 
 # sccache opens many files in parallel; the default macOS soft limit (256) is
 # too low and causes "Too many open files" during large builds.


### PR DESCRIPTION
A 60 GiB cap preserves useful compiler caching without allowing the cache to regrow to its pre-cleanup size.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (GPT-5.6 Sol) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>